### PR TITLE
#8 - Add Code Coverage Package

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -37,16 +37,6 @@ jobs:
       - run:
           name: "Run PHP Unit Test"
           command: "./vendor/bin/phpunit"
-  # unit_test_and_coverage:
-  #   <<: *defaults
-    # steps:
-    #   - restore_cache:
-    # #       key: flexmart-auth-{{ .Branch }}-{{ .Environment.CIRCLE_SHA1 }}
-# workflows:
-  # version: 2
-  # test_unit:
-    # jobs:
-    #   - checkout_code
-    #   - unit_test_and_coverage:
-    #       requires:
-    #         - checkout_code
+      - run:
+          name: "Upload to codecov"
+          command: "bash <(curl -s https://codecov.io/bash)"

--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,5 @@ npm-debug.log
 yarn-error.log
 tags
 *.swp
+coverage.xml
+tests/coverage

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,8 @@
         "mockery/mockery": "^1.3.1",
         "nunomaduro/collision": "^4.1",
         "phpunit/phpunit": "^8.5",
-        "sempro/phpunit-pretty-print": "^1.2"
+        "sempro/phpunit-pretty-print": "^1.2",
+        "phpunit/php-code-coverage": "7.0.10"
     },
     "config": {
         "optimize-autoloader": true,

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -18,6 +18,11 @@
             <directory suffix=".php">./app</directory>
         </whitelist>
     </filter>
+    <logging>
+        <log lowUpperBound="50" highLowerBound="95" type="coverage-text" target="php://stdout"/>
+        <log lowUpperBound="50" highLowerBound="95" type="coverage-html" target="tests/coverage/" showUncoveredFiles="true"/>
+        <log lowUpperBound="50" highLowerBound="95" type="coverage-clover" target="coverage.xml" showUncoveredFiles="true"/>
+    </logging>
     <php>
         <server name="APP_ENV" value="testing"/>
         <server name="BCRYPT_ROUNDS" value="4"/>

--- a/tests/Feature/user/UserAuthenticationTest.php
+++ b/tests/Feature/user/UserAuthenticationTest.php
@@ -3,11 +3,7 @@
 namespace Tests\Feature\user;
 
 use App\User;
-use Illuminate\Foundation\Testing\RefreshDatabase;
-use Illuminate\Foundation\Testing\WithFaker;
-use Laravel\Sanctum\Sanctum;
 use Tests\TestCase;
-
 class UserAuthenticationTest extends TestCase
 {
     /**


### PR DESCRIPTION
This PR closes #8.

Setup Instructions:
1. Run` composer install`
2. Install Xdebug, if you are using Laragon, this maybe already installed. If not you can use PECL to install
3. run `phpunit`

It should now report the lines of code that are not covered


For further reading:

https://github.com/sebastianbergmann/php-code-coverage
https://phpunit.readthedocs.io/en/9.0/code-coverage-analysis.html
https://phpunit.readthedocs.io/en/9.0/configuration.html?highlight=highLowerBound#the-logging-element