### PR TITLE
[#20] - Add Users Login History Migration

### DIFF
--- a/database/migrations/2020_05_21_210248_create_users_login_history_table.php
+++ b/database/migrations/2020_05_21_210248_create_users_login_history_table.php
@@ -1,0 +1,34 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class CreateUsersLoginHistoryTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('users_login_history', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('user_id');
+            $table->string('ip_address');
+            $table->string('device_used');
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('users_login_history');
+    }
+}


### PR DESCRIPTION
This fixes [#20] - **Add User Login History Migration**

- Created `users_login_history` table
- Created columns
   - `user_id` - _FK_
   - `ip_address`
   - `device_used`
   - `timestamps` - default
