### PR TITLE
Added resend countdown and mobile prefix validation

### DIFF
--- a/app/Http/Controllers/Api/MobileValidationController.php
+++ b/app/Http/Controllers/Api/MobileValidationController.php
@@ -13,10 +13,19 @@ class MobileValidationController extends Controller
 {
     private const CODE_EXPIRATION = 900; // 15 minutes
     private const KEY_PREFIX = 'verified-';
+    private const VALID_MOBILE_REGEX = [
+        '0[5-9]', '10', '12', '1[5-9]', '2[0-9]', '3[0-9]', '4[0-3]', '4[5-9]', '50',
+        '5[5-6]', '61', '6[5-7]', '7[3-5]', '7[7-9]', '9[5-9]'
+    ];
 
     public function store(Request $request)
     {
-        $request->validate(['mobile_number' => 'required|unique:users,mobile_number|size:13']);
+        $request->validate(['mobile_number' => [
+            'required',
+            'unique:users,mobile_number',
+            'regex:/^\+639('. implode('|', self::VALID_MOBILE_REGEX).')\d{7}/'
+            ]
+        ]);
 
         $token = $this->handleOtp(request('mobile_number'));
 

--- a/public/mix-manifest.json
+++ b/public/mix-manifest.json
@@ -1,5 +1,5 @@
 {
-    "/js/app.js": "/js/app.js?id=59d99fc4ef0d5152778a",
+    "/js/app.js": "/js/app.js?id=956bd7fdc1599fd641bf",
     "/css/app.css": "/css/app.css?id=e9db132db25672848348",
     "/js/manifest.js": "/js/manifest.js?id=41f053ba9a94d81b39f8",
     "/js/vendor.js": "/js/vendor.js?id=54d91bd34e2527d405d7"

--- a/resources/js/components/MobileNumber.vue
+++ b/resources/js/components/MobileNumber.vue
@@ -2,7 +2,6 @@
     <div class="mobile-number-input">
         <span class="prefix">{{ prefix }}</span>
         <input
-            type="text"
             placeholder="Mobile number"
             name="mobile_number"
             :value="value"
@@ -25,7 +24,11 @@
         },
         methods: {
             emitValue(value) {
-                this.$emit('input-mobile', this.prefix + value.target.value)
+                const mobile = value.target.value
+                if (/^\d{1,10}$/.test(mobile))
+                    // only accept up to 10 digits
+                    this.$emit('input-mobile', this.prefix + mobile)
+                else value.target.value = mobile.slice(0, -1) // disable input
             }
         }
     }

--- a/tests/Feature/MobileValidationTest.php
+++ b/tests/Feature/MobileValidationTest.php
@@ -51,4 +51,19 @@ class MobileValidationTest extends TestCase
                 'errors' => [ "mobile_number" => []]
             ]);
     }
+
+    /**
+     * @test
+     */
+    public function it_should_return_error_if_mobile_prefix_was_invalid()
+    {
+        $request = [
+            'mobile_number' => '+639114563216'
+        ];
+        $this->postJson('api/validate', $request)
+             ->assertStatus(422)
+             ->assertJson([
+                 'errors' => [ "mobile_number" => []]
+             ]);
+    }
 }


### PR DESCRIPTION
Added resend countdown dripcoder20/flexmart-auth#44
Added validation on mobile number dripcoder20/flexmart-auth#47

**For Tester**
1. compile vue
2. serve page
3. sign up mobile verification should not accept letters and must be with valid prefix
`*Important: refer to prefix` [list](https://www.prefix.ph/prefixes/2020-complete-list-of-philippine-mobile-network-prefixes/)
4. valid prefix should redirect to verification otp (will not accept letters)
5. a countdown should be display for resending
6. clicking resend will reset the count to 30
